### PR TITLE
feat(blog): redesign index page with hero, topic chips, post cards

### DIFF
--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: blog
+title: ""
 permalink: /blog/ # <--- ADD THIS LINE! This is for the first page: /blog/
 
 pagination:
@@ -15,29 +15,34 @@ pagination:
     after: 3  # The number of links after the current page
 ---
 
-<div class="post">
-
-  <div class="header-bar">
-    <h1>{{ site.blog_name }}</h1>
-    <h2>{{ site.blog_description }}</h2>
-  </div>
+<div class="llm360-blog-index">
+  <section class="llm360-blog-hero">
+    <p class="llm360-blog-eyebrow">Open notes from the LLM360 team</p>
+    <h1 class="llm360-blog-title">{{ site.blog_name }}</h1>
+    <p class="llm360-blog-subtitle">{{ site.blog_description }}</p>
+    <p class="llm360-blog-intro">
+      Research updates, release notes, evaluations, and behind-the-scenes lessons from building open and transparent language models.
+    </p>
+  </section>
 
   {% if site.display_tags %}
-  <div class="tag-list">
+  <div class="tag-list llm360-blog-topics">
+    <p class="llm360-blog-topics-label">Browse topics</p>
     <ul class="p-0 m-0">
       {% for tag in site.display_tags %}
         <li>
-          <i class="fas fa-hashtag fa-sm"></i> <a href="{{ tag | slugify | prepend: '/blog/tag/' | relative_url }}">{{ tag }}</a>
+          <a class="llm360-blog-topic-chip" href="{{ tag | slugify | prepend: '/blog/tag/' | relative_url }}">
+            <i class="fas fa-hashtag fa-sm"></i>
+            <span>{{ tag }}</span>
+          </a>
         </li>
-        {% unless forloop.last %}
-          <p>&bull;</p>
-        {% endunless %}
       {% endfor %}
     </ul>
   </div>
   {% endif %}
 
-  <ul class="post-list">
+  {% if paginator.posts and paginator.posts != empty %}
+  <ul class="post-list llm360-blog-post-list">
     {% for post in paginator.posts %}
 
     {% if post.external_source == blank %}
@@ -49,53 +54,77 @@ pagination:
     {% assign tags = post.tags | join: "" %}
     {% assign categories = post.categories | join: "" %}
 
-    <li>
-      <h3>
-        {% if post.redirect == blank %}
-          <a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>
-        {% else %}
-          {% if post.redirect contains '://' %}
-            <a class="post-title" href="{{ post.redirect }}" target="_blank">{{ post.title }}</a>
-            <svg width="2rem" height="2rem" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
-              <path d="M17 13.5v6H5v-12h6m3-3h6v6m0-6-9 9" class="icon_svg-stroke" stroke="#999" stroke-width="1.5" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"></path>
-            </svg>
+    <li class="llm360-blog-post-item">
+      <article class="llm360-blog-card">
+        <p class="llm360-blog-meta post-meta">
+          <span class="llm360-blog-meta-item">{{ post.date | date: '%B %-d, %Y' }}</span>
+          <span class="llm360-blog-meta-divider">&middot;</span>
+          <span class="llm360-blog-meta-item">{{ read_time }} min read</span>
+          {%- if post.external_source %}
+          <span class="llm360-blog-meta-divider">&middot;</span>
+          <span class="llm360-blog-meta-item">{{ post.external_source }}</span>
+          {%- endif %}
+        </p>
+
+        <h2 class="llm360-blog-post-title">
+          {% if post.redirect == blank %}
+            <a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>
           {% else %}
-            <a class="post-title" href="{{ post.redirect | relative_url }}">{{ post.title }}</a>
+            {% if post.redirect contains '://' %}
+              <a class="post-title" href="{{ post.redirect }}" target="_blank" rel="noopener noreferrer">
+                {{ post.title }}
+              </a>
+              <svg class="llm360-blog-external-icon" width="1.1rem" height="1.1rem" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path d="M17 13.5v6H5v-12h6m3-3h6v6m0-6-9 9" class="icon_svg-stroke" stroke="currentColor" stroke-width="1.5" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            {% else %}
+              <a class="post-title" href="{{ post.redirect | relative_url }}">{{ post.title }}</a>
+            {% endif %}
           {% endif %}
+        </h2>
+
+        {% if post.description != blank %}
+        <p class="llm360-blog-excerpt">{{ post.description }}</p>
         {% endif %}
-      </h3>
-      <p>{{ post.description }}</p>
-      <p class="post-meta">
-        {{ read_time }} min read &nbsp; &middot; &nbsp;
-        {{ post.date | date: '%B %-d, %Y' }}
-        {%- if post.external_source %}
-        &nbsp; &middot; &nbsp; {{ post.external_source }}
-        {%- endif %}
-      </p>
-      <p class="post-tags">
-        <a href="{{ year | prepend: '/blog/' | relative_url }}">
-          <i class="fas fa-calendar fa-sm"></i> {{ year }} </a>
+
+        <div class="llm360-blog-taxonomy post-tags">
+          <a class="llm360-blog-chip llm360-blog-chip-year" href="{{ year | prepend: '/blog/' | relative_url }}">
+            <i class="fas fa-calendar fa-sm"></i>
+            <span>{{ year }}</span>
+          </a>
 
           {% if tags != "" %}
-          &nbsp; &middot; &nbsp;
             {% for tag in post.tags %}
-            <a href="{{ tag | slugify | prepend: '/blog/tag/' | relative_url }}">
-              <i class="fas fa-hashtag fa-sm"></i> {{ tag }}</a> &nbsp;
-              {% endfor %}
+            <a class="llm360-blog-chip" href="{{ tag | slugify | prepend: '/blog/tag/' | relative_url }}">
+              <i class="fas fa-hashtag fa-sm"></i>
+              <span>{{ tag }}</span>
+            </a>
+            {% endfor %}
           {% endif %}
 
           {% if categories != "" %}
-          &nbsp; &middot; &nbsp;
             {% for category in post.categories %}
-            <a href="{{ category | slugify | prepend: '/blog/category/' | relative_url }}">
-              <i class="fas fa-tag fa-sm"></i> {{ category }}</a> &nbsp;
-              {% endfor %}
+            <a class="llm360-blog-chip" href="{{ category | slugify | prepend: '/blog/category/' | relative_url }}">
+              <i class="fas fa-tag fa-sm"></i>
+              <span>{{ category }}</span>
+            </a>
+            {% endfor %}
           {% endif %}
-    </p>
+        </div>
+      </article>
     </li>
 
     {% endfor %}
   </ul>
+  {% else %}
+  <div class="llm360-blog-empty-state">
+    <p class="llm360-blog-empty-kicker">Nothing published yet</p>
+    <h2>The first posts are on the way.</h2>
+    <p>
+      This space is where we will share technical notes, model updates, evaluation write-ups, and small findings from the team.
+    </p>
+  </div>
+  {% endif %}
 
   {% include pagination.html %}
 

--- a/_posts/2025-07-22-blog-kickstart.md
+++ b/_posts/2025-07-22-blog-kickstart.md
@@ -2,6 +2,7 @@
 layout: post
 title: Hello, Welcome to the LLM360 Blog Post Series!
 date: 2025-07-22 11:00:00 -0700 # Use current date/time
+description: Short notes on what the LLM360 blog will cover, from quick experiments to transparent training lessons.
 categories: [general]
 tags: [LLM360]
 math: true # Keep this to test math rendering

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -1,5 +1,337 @@
 /* _sass/_custom.scss */
 
-.test-class {
-    color: red;
+.post-header .post-title:empty,
+.post-header .post-description:empty {
+  display: none;
+}
+
+.llm360-blog-index {
+  --llm360-blog-accent-soft: color-mix(in srgb, var(--global-theme-color) 10%, var(--global-card-bg-color));
+  --llm360-blog-border: color-mix(in srgb, var(--global-divider-color) 82%, transparent);
+  --llm360-blog-card-shadow: 0 18px 40px rgba(15, 23, 42, 0.06);
+  --llm360-blog-card-shadow-hover: 0 22px 48px rgba(15, 23, 42, 0.1);
+  margin-top: 0.25rem;
+}
+
+.llm360-blog-hero {
+  position: relative;
+  margin-bottom: 2.75rem;
+  padding: 2.25rem 2rem 2.1rem;
+  border: 1px solid var(--llm360-blog-border);
+  border-radius: 28px;
+  background:
+    radial-gradient(circle at top right, color-mix(in srgb, var(--global-theme-color) 16%, transparent), transparent 38%),
+    linear-gradient(180deg, color-mix(in srgb, var(--global-card-bg-color) 96%, var(--global-theme-color)), var(--global-card-bg-color));
+  overflow: hidden;
+}
+
+.llm360-blog-hero::after {
+  content: "";
+  position: absolute;
+  inset: auto -3rem -3.25rem auto;
+  width: 11rem;
+  height: 11rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--global-theme-color) 9%, transparent);
+  filter: blur(0.5px);
+}
+
+.llm360-blog-eyebrow {
+  position: relative;
+  z-index: 1;
+  margin: 0 0 0.9rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--global-theme-color);
+}
+
+.llm360-blog-title {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  font-size: clamp(2.6rem, 7vw, 4.8rem);
+  line-height: 0.96;
+  letter-spacing: -0.045em;
+}
+
+.llm360-blog-subtitle {
+  position: relative;
+  z-index: 1;
+  margin: 1rem 0 0;
+  max-width: 40rem;
+  font-size: clamp(1.15rem, 2.4vw, 1.5rem);
+  line-height: 1.35;
+  color: var(--global-text-color);
+}
+
+.llm360-blog-intro {
+  position: relative;
+  z-index: 1;
+  margin: 1rem 0 0;
+  max-width: 36rem;
+  font-size: 1rem;
+  line-height: 1.75;
+  color: var(--global-text-color-light);
+}
+
+.llm360-blog-topics {
+  margin-bottom: 2rem;
+}
+
+.llm360-blog-topics-label {
+  margin: 0 0 0.75rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--global-text-color-light);
+}
+
+.llm360-blog-topics ul,
+.llm360-blog-taxonomy {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  align-items: center;
+}
+
+.llm360-blog-topics li {
+  list-style: none;
+}
+
+.llm360-blog-topic-chip,
+.llm360-blog-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.48rem 0.82rem;
+  border: 1px solid var(--llm360-blog-border);
+  border-radius: 999px;
+  background: var(--global-card-bg-color);
+  color: var(--global-text-color);
+  font-size: 0.92rem;
+  line-height: 1;
+  text-decoration: none;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease,
+    box-shadow 160ms ease,
+    background-color 160ms ease;
+}
+
+.llm360-blog-topic-chip:hover,
+.llm360-blog-topic-chip:focus-visible,
+.llm360-blog-chip:hover,
+.llm360-blog-chip:focus-visible {
+  color: var(--global-theme-color);
+  border-color: color-mix(in srgb, var(--global-theme-color) 45%, var(--llm360-blog-border));
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
+  text-decoration: none;
+  transform: translateY(-1px);
+}
+
+.llm360-blog-post-list {
+  margin: 0;
+  padding: 0;
+}
+
+.llm360-blog-post-item {
+  list-style: none;
+  margin: 0 0 1rem;
+}
+
+.llm360-blog-card {
+  padding: 1.55rem 1.55rem 1.35rem;
+  border: 1px solid var(--llm360-blog-border);
+  border-radius: 22px;
+  background: var(--global-card-bg-color);
+  box-shadow: var(--llm360-blog-card-shadow);
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    border-color 180ms ease;
+}
+
+.llm360-blog-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--llm360-blog-card-shadow-hover);
+  border-color: color-mix(in srgb, var(--global-theme-color) 28%, var(--llm360-blog-border));
+}
+
+.llm360-blog-meta {
+  margin-bottom: 0.7rem;
+  font-size: 0.92rem;
+  color: var(--global-text-color-light);
+}
+
+.llm360-blog-meta-item,
+.llm360-blog-meta-divider {
+  color: inherit;
+}
+
+.llm360-blog-post-title {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin: 0;
+  font-size: clamp(1.45rem, 3vw, 1.9rem);
+  line-height: 1.15;
+  letter-spacing: -0.03em;
+}
+
+.llm360-blog-post-title .post-title {
+  color: var(--global-text-color);
+  text-decoration: none;
+}
+
+.llm360-blog-post-title .post-title:hover,
+.llm360-blog-post-title .post-title:focus-visible {
+  color: var(--global-theme-color);
+  text-decoration: none;
+}
+
+.llm360-blog-external-icon {
+  flex: 0 0 auto;
+  color: var(--global-text-color-light);
+}
+
+.llm360-blog-excerpt {
+  margin: 0.85rem 0 1.1rem;
+  max-width: 44rem;
+  font-size: 1rem;
+  line-height: 1.8;
+  color: var(--global-text-color-light);
+}
+
+.llm360-blog-taxonomy {
+  margin-top: 0.2rem;
+}
+
+.llm360-blog-chip {
+  font-size: 0.85rem;
+}
+
+.llm360-blog-chip-year {
+  background: var(--llm360-blog-accent-soft);
+}
+
+.llm360-blog-empty-state {
+  padding: 2rem 1.6rem;
+  border: 1px dashed var(--llm360-blog-border);
+  border-radius: 24px;
+  background: color-mix(in srgb, var(--global-card-bg-color) 94%, var(--global-theme-color));
+}
+
+.llm360-blog-empty-state h2 {
+  margin: 0 0 0.55rem;
+  font-size: 1.65rem;
+}
+
+.llm360-blog-empty-kicker {
+  margin: 0 0 0.7rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--global-theme-color);
+}
+
+.llm360-blog-empty-state p:last-child {
+  margin-bottom: 0;
+  color: var(--global-text-color-light);
+}
+
+.llm360-blog-index .pagination,
+.llm360-blog-index .pager {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  align-items: center;
+  margin-top: 2rem;
+}
+
+.llm360-blog-index .pagination a,
+.llm360-blog-index .pagination span,
+.llm360-blog-index .pager a,
+.llm360-blog-index .pager span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.75rem;
+  padding: 0.6rem 0.95rem;
+  border: 1px solid var(--llm360-blog-border);
+  border-radius: 999px;
+  background: var(--global-card-bg-color);
+  color: var(--global-text-color);
+  text-decoration: none;
+}
+
+.llm360-blog-index .pagination a:hover,
+.llm360-blog-index .pagination a:focus-visible,
+.llm360-blog-index .pager a:hover,
+.llm360-blog-index .pager a:focus-visible {
+  color: var(--global-theme-color);
+  border-color: color-mix(in srgb, var(--global-theme-color) 45%, var(--llm360-blog-border));
+  text-decoration: none;
+}
+
+@media (max-width: 768px) {
+  .llm360-blog-hero {
+    padding: 1.7rem 1.2rem 1.55rem;
+    border-radius: 22px;
+  }
+
+  .llm360-blog-topics,
+  .llm360-blog-empty-state {
+    padding-left: 0.15rem;
+    padding-right: 0.15rem;
+  }
+
+  .llm360-blog-card {
+    padding: 1.2rem 1.05rem 1.05rem;
+    border-radius: 18px;
+  }
+
+  .llm360-blog-meta {
+    font-size: 0.88rem;
+  }
+
+  .llm360-blog-post-title {
+    font-size: 1.35rem;
+  }
+
+  .llm360-blog-topic-chip,
+  .llm360-blog-chip {
+    width: auto;
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .llm360-blog-index {
+    margin-top: 0;
+  }
+
+  .llm360-blog-subtitle {
+    font-size: 1.05rem;
+  }
+
+  .llm360-blog-intro,
+  .llm360-blog-excerpt {
+    font-size: 0.95rem;
+    line-height: 1.65;
+  }
+
+  .llm360-blog-meta-divider {
+    margin: 0 0.2rem;
+  }
+
+  .llm360-blog-index .pagination,
+  .llm360-blog-index .pager {
+    justify-content: flex-start;
+  }
 }


### PR DESCRIPTION
## Summary
- Replaces the plain blog index layout with a hero section, pill-shaped topic filters, and per-post cards.
- Adds an empty-state block for when no posts are published.
- Hover/focus-visible states for accessibility, `rel="noopener noreferrer"` on external links.
- Mobile-responsive breakpoints at 768px and 480px.
- Styling uses existing theme tokens (`--global-theme-color`, `--global-card-bg-color`, etc.) via `color-mix` for theme integration.
- Adds a `description` frontmatter field to the kickstart post so it renders an excerpt in the new card layout.

## Files changed
- `_pages/blog.md` — full index page restructure
- `_sass/_custom.scss` — new `.llm360-blog-*` styling system
- `_posts/2025-07-22-blog-kickstart.md` — adds `description:` frontmatter

## Test plan
- [ ] Netlify deploy-preview renders the redesigned blog index
- [ ] Post cards show title, excerpt, date, read time, tags, categories
- [ ] Topic chips filter correctly
- [ ] Empty `page.title` doesn't break tab title or breadcrumbs
- [ ] Mobile layout looks correct at 768px and 480px breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)